### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest-check.yaml
+++ b/.github/workflows/pytest-check.yaml
@@ -1,5 +1,7 @@
 # .github/workflows/app.yaml
 name: PyTest
+permissions:
+  contents: read
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/statisticsnorway/ssb-metodebiblioteket/security/code-scanning/1](https://github.com/statisticsnorway/ssb-metodebiblioteket/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow to set the least privilege required. The most appropriate place is at the root of the workflow file (before `jobs:`), which will apply to all jobs unless overridden at the job level. For a workflow that only checks out code and installs dependencies/tests, the only necessary permission is `contents: read`. This minimizes token permissions if ever used, and aligns with recommended best practices.

Specifically, add the following YAML to the workflow immediately after the `name:` (line 2) and before the `on:` block:
```yaml
permissions:
  contents: read
```

No external dependencies or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
